### PR TITLE
Adding parsing of sanitized string before injection in output cell 

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -111,8 +111,9 @@ function renderOutputs(outputDiv: HTMLElement, outputs: Output[]) {
   outputs.forEach((output) => {
     switch (output.type) {
       case 'log':
-        // md.render(output.data) produces HTML. Sanitize it.
-        const sanitizedLogContent = sanitizeHtml(md.render(output.data));
+       // Decode HTML entities before rendering markdown to handle escaped characters properly
+       const decodedData = decodeHtmlEntities(output.data);
+       const sanitizedLogContent = sanitizeHtml(md.render(decodedData));
         outputHtml += `<div class="console-log">${sanitizedLogContent.toString()}</div>`;
         break;
       case 'error':
@@ -158,6 +159,19 @@ function renderOutputs(outputDiv: HTMLElement, outputs: Output[]) {
   });
 
   setElementInnerHtml(outputDiv, sanitizeHtml(outputHtml));
+}
+
+// Add a utility function to decode HTML entities
+function decodeHtmlEntities(html: string): string {
+  const sanitizedHtml = sanitizeHtml(html);  // First, sanitize the input
+  const entities: { [key: string]: string } = {
+    '&amp;': '&',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&quot;': '"',
+    '&#39;': "'"
+  };
+  return String(sanitizedHtml).replace(/&amp;|&lt;|&gt;|&quot;|&#39;/gi, (match: string) => entities[match as keyof typeof entities] || match);
 }
 
 function parseNotebookFile(content: string) {


### PR DESCRIPTION
In some cases sanitized string gets printed as it is in cascaded markdown cells:
![image](https://github.com/user-attachments/assets/76ee64a8-4103-4b67-9f4c-32f9ce77e91d)
So if we decode it first, then pass it to the sanitizer. I believe this gets fixed:
![image](https://github.com/user-attachments/assets/37c3c676-fb2a-4b5c-ad41-35e4f92f53a4)
